### PR TITLE
Improved parsing abbreviations

### DIFF
--- a/app.js
+++ b/app.js
@@ -1236,7 +1236,7 @@ function registerTriggerAndConditionListeners() {
 
             util.wuLog('forecast text ' + JSON.stringify(forecastText), severity.debug);
 
-            if (util.value_exist(forecastText)) Homey.manager('speech-output').say(forecastText);
+            if (util.value_exist(forecastText)) Homey.manager('speech-output').say(parseAbbreviations(forecastText));
             else {
                 util.wuLog('Read forecast but forecast data is empty: ' + JSON.stringify(forecastData), severity.error);
                 Homey.manager('speech-output').say(__("app.speech.somethingWrong"));

--- a/lib/util.js
+++ b/lib/util.js
@@ -229,16 +229,23 @@ exports.parseAbbreviations = function (text) {
     } else {
         //noinspection JSDuplicatedDeclaration
         var replaceMap = [
+            ['km/u', ' kilometer per hour'],
             ['mph', ' miles per hour'],
+            [' Z ', ' south '],
             [' S ', ' south '],
+            [' ZW ', ' south west '],
             [' SW ', ' south west '],
+            [' WZW ', ' west south west '],
             [' WSW ', ' west south west '],
             [' W ', ' west '],
             [' NW ', ' north west '],
             [' N ', ' north '],
+            [' NO ', ' north east '],
             [' NE ', ' north east '],
+            [' O ', ' east '],
             [' E ', ' east '],
             [' ZO ', ' south east '],
+            [' SE ', ' south east '],
             [/(.*?\d+)(C)\b/gi, function(match, g1) { return g1 + ' degrees celcius'} ]
         ]
     }


### PR DESCRIPTION
I noticed the parsing of the abbreviations only works for the built in voice triggers for app version 1.0.0. This pull request also parses it for the action cards. I also added some extra parsing mappings for people who use English speech.